### PR TITLE
reset version sqla-wrapper < 5.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pydantic-sqlalchemy>=0.0.7,<1
 python-jose[cryptography]==3.2.0
 pytz==2021.1
 redis==3.5.3
-sqla-wrapper>=5.0.0,<6
+sqla-wrapper>=5.0.0,<5.6
 typer>=0.3.2
 uvicorn>=0.12.3,<=0.15


### PR DESCRIPTION
reset version sqla-wrapper < 5.6 to avoid no model exception of sqlalchemy.orm.decl_api