### PR TITLE
Feature: allows custom http host/port and rpc host/port.

### DIFF
--- a/bali/application.py
+++ b/bali/application.py
@@ -57,6 +57,14 @@ class Bali:
         self.kwargs = kwargs
         self.title = kwargs.get('title', 'Bali')
 
+        # http host+port
+        self.http_host = kwargs.get('http_host', '0.0.0.0')  # 127. still works
+        self.http_port = kwargs.get('http_port', 8000)
+
+        # rpc host+port
+        self.rpc_host = kwargs.get('rpc_host', '[::]')
+        self.rpc_port = kwargs.get('rpc_port', 9080)
+
         self._app = None
 
         self._pb2 = None
@@ -93,11 +101,11 @@ class Bali:
     def rpc_servicer(self):
         return self._rpc_servicer
 
-    @staticmethod
-    def _launch_http():
+    def _launch_http(self):
         uvicorn.run(
             "main:app",
-            port=8000,
+            host=self.http_host,  # fix for docker port mapping
+            port=self.http_port,
             reload=True,
             access_log=True,
             reload_excludes=['*.log'],

--- a/bali/servicer.py
+++ b/bali/servicer.py
@@ -49,7 +49,8 @@ def make_grpc_serve(app):
 
     # noinspection PyProtectedMember
     def serve():
-        port = 9080
+        host = app.rpc_host
+        port = app.rpc_port
         server = grpc.server(
             futures.ThreadPoolExecutor(max_workers=10),
             interceptors=[ProcessInterceptor()],
@@ -57,9 +58,10 @@ def make_grpc_serve(app):
 
         servicer = getattr(app._pb2_grpc, servicer_method)
         servicer(app._rpc_servicer(), server)
-        server.add_insecure_port(f'[::]:{port}')
+        server.add_insecure_port(f'{host}:{port}')
         server.start()
-        logger.info("Service started on port: %s (env: %s)", port, 'default')
+        logger.info("RPC Service started on port: %s (env: %s)", port, 'default')
+        print(f"RPC Service started on host: {host}:{port} (env: {'default'})") # async, will not show log
         server.wait_for_termination()
 
     return serve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.poetry]
-name = "bali"
-version = "3.4.1"
+name = "bali-core"
+version = "3.5.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
+
+# fix package dir
+packages = [{include = "bali", from = "."}]
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -13,7 +16,7 @@ greenlet = ">1.0,<=2.0.1"
 aiomysql = "^0.1.1"
 aiosqlite = "^0.18.0"
 dateparser = ">=1.1.0"
-fastapi = {version = ">=0.63.0,<=0.88", extras = ["all"]}
+fastapi = {version = ">=0.69.0,<=0.92", extras = ["all"]}
 fastapi-migrate = "^0.1.1"
 fastapi-pagination = ">=0.9.0,<=0.10"
 grpcio = ">=1.32.0,<=1.50.0"


### PR DESCRIPTION
# 更新说明: 

## 新增功能:

- ✅️ 扩展 Bali(**kwargs) 的 kwargs 参数, 允许用户自定义 http/rpc 服务的 host + port. 修改不影响旧的行为.
    - `http` host 使用 `0.0.0.0`, 是为了修复 `docker` 部署时, 无法访问到 `127.0.0.1` 端口.
    - 改为 `0.0.0.0` 后, `127.0.0.1` 仍然是正常访问的.
    - `rpc` host+port 默认值, 与`旧参数`相同.

## 问题修复:

- ✅️ bug 修复: `poetry` 安装本包时, 会报错, 原因是 `pyproject.toml` 包名错误, 且未指名具体路径.
- ✅️ 更新了 `pyproject.toml` 中 fastapi 版本.


## 测试说明:

- ✅️ 所有修改, 我本机+Docker, 都测试正常.

